### PR TITLE
Fix/TR-5072/Correct the percentage operator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1980,9 +1980,9 @@
             }
         },
         "@oat-sa/expr-eval": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@oat-sa/expr-eval/-/expr-eval-2.1.0.tgz",
-            "integrity": "sha512-eW5dYZnWDk5T4aFxVWaoXOqTxBCooRYDDVzvhD/lByj4N9qigPSKesXM7GOUgZDDLxPCK9nElf1LWoI7Ib885w=="
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/@oat-sa/expr-eval/-/expr-eval-2.1.2.tgz",
+            "integrity": "sha512-pGB6lctCmqsyH/q7t19EK/svj1FrdqiR7VNg2T2MyO9mQ2vcqOYPTTF5gXf+f7GJdwy7gJVHK84Nv24MmgZCDQ=="
         },
         "@oat-sa/prettier-config": {
             "version": "0.1.1",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     },
     "homepage": "https://github.com/oat-sa/tao-calculator-fe#readme",
     "dependencies": {
-        "@oat-sa/expr-eval": "^2.1.0",
+        "@oat-sa/expr-eval": "^2.1.2",
         "decimal.js": "^10.4.3",
         "lodash": "^4.17.21",
         "moo": "^0.5.2"


### PR DESCRIPTION
### Related to: https://oat-sa.atlassian.net/browse/TR-5072

### Summary

Update @oat-sa/expr-eval to version 2.1.2

### Details

Include the fixes:
 - _Fix_ [TR-5072](https://oat-sa.atlassian.net/browse/TR-5072) : Correct precedence for compound percentage operator [#12](https://github.com/oat-sa/expr-eval/pull/12)
 - _Fix_ [TR-5072](https://oat-sa.atlassian.net/browse/TR-5072) : Correct the sum commutativity [#14](https://github.com/oat-sa/expr-eval/pull/14)

### How to test

- run the tests: `npm test`
- launch the sandbox: `npm run dev`
- from the opened sandbox, try the expressions:
    - `50+10#` => should give `55`
    - `50-10#` => should give `45`
    - `50*10#` => should give `5`
    - `50/10#` => should give `500`
    - `10+20+10#` => should give `32`
    - `10-20-10#` => should give `-8`

[TR-5072]: https://oat-sa.atlassian.net/browse/TR-5072?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TR-5072]: https://oat-sa.atlassian.net/browse/TR-5072?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ