### PR TITLE
Feature/TR-5071/Add a strategy for deciding if the expression needs to be evaluated

### DIFF
--- a/src/core/engine.js
+++ b/src/core/engine.js
@@ -28,7 +28,7 @@ import {
     signStrategies,
     suffixStrategies
 } from './strategies';
-import { isFunctionOperator, terms } from './terms.js';
+import { isPrefixedTerm, terms } from './terms.js';
 import tokenizerFactory from './tokenizer.js';
 import tokensHelper from './tokens.js';
 
@@ -886,7 +886,7 @@ function engineFactory({
             // - it is the last result, and the term to add is not an operator
             if (
                 !addOperator &&
-                !isFunctionOperator(term.value) &&
+                !isPrefixedTerm(term.value) &&
                 tokensList.length === 1 &&
                 ((tokensHelper.getToken(currentToken) === 'NUM0' && name !== 'DOT') ||
                     tokensHelper.getToken(currentToken) === 'VAR_ANS')
@@ -898,7 +898,7 @@ function engineFactory({
                 let value = term.value;
                 let at = position;
 
-                // will replace the terms a the current position with respect to a list strategies
+                // will replace the terms at the current position with respect to a list of strategies
                 // typically if:
                 // - the last term is an operator and the term to add is an operator
                 // - the operator is not unary (percent or factorial)
@@ -948,7 +948,7 @@ function engineFactory({
          * @fires term when the term has been added
          */
         insertTerm(name) {
-            const prefixed = isFunctionOperator(name);
+            const prefixed = isPrefixedTerm(name);
             if (prefixed) {
                 name = name.substring(1);
             }

--- a/src/core/expression.js
+++ b/src/core/expression.js
@@ -16,7 +16,7 @@
  * Copyright (c) 2019-2023 Open Assessment Technologies SA ;
  */
 
-import { isFunctionOperator, signOperators, terms, types } from './terms.js';
+import { isPrefixedTerm, isSignOperator, terms, types } from './terms.js';
 import tokensHelper from './tokens.js';
 import tokenizerFactory from './tokenizer.js';
 
@@ -229,7 +229,7 @@ const expressionHelper = {
                 exponent: null,
                 startExponent: null,
                 endExponent: [],
-                prefixed: isFunctionOperator(token.value),
+                prefixed: isPrefixedTerm(token.value),
                 elide: false
             };
 
@@ -447,10 +447,7 @@ function exponentOnTheRight(renderedTerms, index) {
     }
 
     // only take care of actual operand value or sub expression (starting from the left)
-    if (
-        term &&
-        (tokensHelper.isOperand(term.type) || term.token === 'LPAR' || signOperators.indexOf(term.token) >= 0)
-    ) {
+    if (term && (tokensHelper.isOperand(term.type) || term.token === 'LPAR' || isSignOperator(term.token))) {
         term.startExponent = identifier;
 
         // we use an internal loop as exponents could be chained
@@ -458,7 +455,7 @@ function exponentOnTheRight(renderedTerms, index) {
             shouldContinue = false;
 
             // functions are attached to an operand, and this link should be kept
-            while (index < last && (tokensHelper.isFunction(term.type) || signOperators.indexOf(term.token) >= 0)) {
+            while (index < last && (tokensHelper.isFunction(term.type) || isSignOperator(term.token))) {
                 nextTerm();
             }
 

--- a/src/core/strategies/index.js
+++ b/src/core/strategies/index.js
@@ -23,4 +23,5 @@ export * from './prefix.js';
 export * from './replace.js';
 export * from './sign.js';
 export * from './suffix.js';
+export * from './trigger.js';
 /* c8 ignore end */

--- a/src/core/strategies/replace.js
+++ b/src/core/strategies/replace.js
@@ -16,7 +16,7 @@
  * Copyright (c) 2023 Open Assessment Technologies SA ;
  */
 
-import { signOperators } from '../terms.js';
+import { isSignOperator } from '../terms.js';
 import tokensHelper from '../tokens.js';
 
 /**
@@ -43,7 +43,7 @@ export const replaceStrategies = [
         const isOperator = () => currentTerm && tokensHelper.isBinaryOperator(currentTerm);
 
         if (addOperator && isOperator()) {
-            if ((newTerm.token === 'SUB' || newTerm.token === 'NEG') && signOperators.indexOf(currentTerm.token) < 0) {
+            if ((newTerm.token === 'SUB' || newTerm.token === 'NEG') && !isSignOperator(currentTerm.token)) {
                 return 0;
             }
 

--- a/src/core/strategies/test/trigger.spec.js
+++ b/src/core/strategies/test/trigger.spec.js
@@ -1,0 +1,81 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2023 Open Assessment Technologies SA ;
+ */
+
+import { terms } from '../../terms.js';
+import tokenizerFactory from '../../tokenizer.js';
+import { applyContextStrategies } from '../helpers.js';
+import { triggerStrategies } from '../trigger.js';
+
+const tokenizer = tokenizerFactory();
+
+describe('triggerStrategies', () => {
+    it('is a collection', () => {
+        expect(triggerStrategies).toEqual(expect.any(Array));
+        expect(triggerStrategies.length).toBeGreaterThan(0);
+        triggerStrategies.forEach(strategy => {
+            expect(strategy).toEqual(expect.any(Function));
+        });
+    });
+
+    describe.each([
+        ['', false],
+        ['3', false],
+        ['123', false],
+        ['3+4', true],
+        ['1324+246', true],
+        ['(1324+246)*23', true],
+        ['(1324+246', false],
+        ['(1324+246)', true],
+        ['(12+3*(98-43)+5!', false],
+        ['(12+3*(98-43)+5!)', true],
+        ['1324+cos PI', true],
+        ['4 @nthrt', false],
+        ['4 @nthrt 189', true],
+        ['50#', false],
+        ['10+50#', true],
+        ['50#*3', true]
+    ])('detects if the expression "%s" should be evaluated', (expression, allowed) => {
+        it.each([
+            ['', false],
+            ['NEG', true],
+            ['SUB', true],
+            ['POS', true],
+            ['ADD', true],
+            ['MUL', true],
+            ['DIV', true],
+            ['MOD', true],
+            ['POW', true],
+            ['FAC', false],
+            ['ASSIGN', false],
+            ['PERCENT', false],
+            ['NTHRT', true],
+            ['LPAR', false],
+            ['RPAR', false],
+            ['COMMA', false],
+            ['SIN', false],
+            ['NUM3', false],
+            ['VAR_ANS', false],
+            ['PI', false]
+        ])('before adding the token "%s"', (token, trigger) => {
+            const tokens = tokenizer.tokenize(expression);
+            const expected = (allowed && trigger) || null;
+
+            expect(applyContextStrategies([...tokens, terms[token]], triggerStrategies)).toStrictEqual(expected);
+        });
+    });
+});

--- a/src/core/strategies/test/trigger.spec.js
+++ b/src/core/strategies/test/trigger.spec.js
@@ -73,7 +73,7 @@ describe('triggerStrategies', () => {
             ['PI', false]
         ])('before adding the token "%s"', (token, trigger) => {
             const tokens = tokenizer.tokenize(expression);
-            const expected = (allowed && trigger) || null;
+            const expected = allowed && trigger;
 
             expect(applyContextStrategies([...tokens, terms[token]], triggerStrategies)).toStrictEqual(expected);
         });

--- a/src/core/strategies/trigger.js
+++ b/src/core/strategies/trigger.js
@@ -30,17 +30,26 @@ import tokensHelper from '../tokens.js';
  */
 export const triggerStrategies = [
     /**
-     * Check if the expression must be evaluated before adding the new term.
+     * Checks if the expression contains enough terms to let the next strategy applies.
      * @param {token[]} tokens - The list of tokens on which apply the strategy.
-     * @returns {boolean|null} - Returns `true` if the current tokens must be evaluated.
-     * Otherwise, returns `null` if the strategy does not apply.
+     * @returns {boolean|null} - Returns `false` if the expression does not contain enough tokens.
+     * Otherwise, returns `null` if the next strategy could apply.
      */
-    function triggerEval(tokens = []) {
+    function expressionFilled(tokens = []) {
         if (tokens.length < 4) {
-            return null;
+            return false;
         }
 
-        const currentTokens = tokens.slice(0, -1);
+        return null;
+    },
+
+    /**
+     * Checks if the new term needs the expression to be evaluated before.
+     * @param {token[]} tokens - The list of tokens on which apply the strategy.
+     * @returns {boolean|null} - Returns `false` if the new term to does not require the expression to be evaluated.
+     * Otherwise, returns `null` if the next strategy could apply.
+     */
+    function addingOperator(tokens = []) {
         const [newToken] = tokens.slice(-1);
         const newTerm = tokensHelper.getTerm(newToken);
 
@@ -49,9 +58,20 @@ export const triggerStrategies = [
             newTerm.token === 'ASSIGN' ||
             (!isFunctionOperator(newTerm.token) && !tokensHelper.isBinaryOperator(newTerm))
         ) {
-            return null;
+            return false;
         }
 
+        return null;
+    },
+
+    /**
+     * Checks if the expression can be evaluated before adding the new term.
+     * @param {token[]} tokens - The list of tokens on which apply the strategy.
+     * @returns {boolean|null} - Returns `true` if the current expression can be evaluated.
+     * Otherwise, returns `false`.
+     */
+    function expressionComplete(tokens = []) {
+        const currentTokens = tokens.slice(0, -1);
         const operands = counterFactory();
         const operators = counterFactory();
         let parenthesis = 0;
@@ -79,7 +99,7 @@ export const triggerStrategies = [
             return true;
         }
 
-        return null;
+        return false;
     }
 ];
 

--- a/src/core/strategies/trigger.js
+++ b/src/core/strategies/trigger.js
@@ -1,0 +1,92 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2023 Open Assessment Technologies SA ;
+ */
+
+import { counterFactory } from '../../utils';
+import { isFunctionOperator } from '../terms';
+import tokensHelper from '../tokens.js';
+
+/**
+ * List of known strategies to apply to the current tokens when adding a new term.
+ * This will help to decide if existing tokens need to be evaluated prior to add the term.
+ * Each strategy expect a list of tokens in this order: ..., current, next.
+ * The result will be `true` if the current tokens must be evaluated.
+ * Otherwise, it will be `null` if no strategy applies.
+ * @type {contextStrategy[]}
+ */
+export const triggerStrategies = [
+    /**
+     * Check if the expression must be evaluated before adding the new term.
+     * @param {token[]} tokens - The list of tokens on which apply the strategy.
+     * @returns {boolean|null} - Returns `true` if the current tokens must be evaluated.
+     * Otherwise, returns `null` if the strategy does not apply.
+     */
+    function triggerEval(tokens = []) {
+        if (tokens.length < 4) {
+            return null;
+        }
+
+        const currentTokens = tokens.slice(0, -1);
+        const [newToken] = tokens.slice(-1);
+        const newTerm = tokensHelper.getTerm(newToken);
+
+        if (
+            !newTerm ||
+            newTerm.token === 'ASSIGN' ||
+            (!isFunctionOperator(newTerm.token) && !tokensHelper.isBinaryOperator(newTerm))
+        ) {
+            return null;
+        }
+
+        const operands = counterFactory();
+        const operators = counterFactory();
+        let parenthesis = 0;
+        currentTokens.forEach(token => {
+            const term = tokensHelper.getTerm(token);
+            const functionOperator = isFunctionOperator(term.token);
+
+            operands.check(tokensHelper.isOperand(term) && !functionOperator);
+            operators.check(tokensHelper.isBinaryOperator(term) || functionOperator);
+
+            switch (term.token) {
+                case 'RPAR':
+                    parenthesis--;
+                    break;
+
+                case 'LPAR':
+                    parenthesis++;
+                    break;
+            }
+        });
+        operands.check();
+        operators.check();
+
+        if (!parenthesis && operands.count > 1 && operators.count && operands.count > operators.count) {
+            return true;
+        }
+
+        return null;
+    }
+];
+
+/**
+ * @typedef {import('../tokenizer.js').token} token
+ */
+
+/**
+ * @typedef {import('./helpers.js').contextStrategy} contextStrategy
+ */

--- a/src/core/terms.js
+++ b/src/core/terms.js
@@ -29,7 +29,7 @@ const rePrefixedTerm = /^@[a-zA-Z_]\w*$/;
  * @param {string} name - The term to check.
  * @returns {boolean} - Returns `true` if the term is prefixed.
  */
-export const isFunctionOperator = name => rePrefixedTerm.test(name);
+export const isPrefixedTerm = name => rePrefixedTerm.test(name);
 
 /**
  * Formats a math element as exponent.
@@ -113,6 +113,26 @@ export const types = {
  * @type {string[]}
  */
 export const signOperators = ['NEG', 'POS', 'SUB', 'ADD'];
+
+/**
+ * List of tokens representing functions that can be considered binary operators.
+ * @type {string[]}
+ */
+export const functionOperators = ['NTHRT'];
+
+/**
+ * Checks if a token is a sign operator.
+ * @param {string} token - The token name to check.
+ * @returns {boolean} - Returns `true` if the token is a sign operator ; otherwise, returns `false`.
+ */
+export const isSignOperator = token => signOperators.includes(token);
+
+/**
+ * Checks if a token is a function that can be used as an operator.
+ * @param {string} token - The token name to check.
+ * @returns {boolean} - Returns `true` if the token is a function operator ; otherwise, returns `false`.
+ */
+export const isFunctionOperator = token => functionOperators.includes(token);
 
 /**
  * @typedef {object} term - Represents a tokenizable term

--- a/src/core/test/terms.spec.js
+++ b/src/core/test/terms.spec.js
@@ -20,7 +20,10 @@ import {
     exponent,
     exponentLeft,
     exponentRight,
+    functionOperators,
     isFunctionOperator,
+    isPrefixedTerm,
+    isSignOperator,
     signOperators,
     subscript,
     subscriptRight,
@@ -29,9 +32,9 @@ import {
     types
 } from '../terms.js';
 
-describe('isFunctionOperator', () => {
+describe('isPrefixedTerm', () => {
     it('is a helper', () => {
-        expect(isFunctionOperator).toEqual(expect.any(Function));
+        expect(isPrefixedTerm).toEqual(expect.any(Function));
     });
 
     it.each([
@@ -39,6 +42,39 @@ describe('isFunctionOperator', () => {
         ['sqrt', false],
         ['', false]
     ])('tells if %s is prefixed', (value, expected) => {
+        expect(isPrefixedTerm(value)).toStrictEqual(expected);
+    });
+});
+
+describe('isSignOperator', () => {
+    it('is a helper', () => {
+        expect(isSignOperator).toEqual(expect.any(Function));
+    });
+
+    it.each([
+        ['', false],
+        ['MUL', false],
+        ['NEG', true],
+        ['SUB', true],
+        ['POS', true],
+        ['ADD', true]
+    ])('tells if %s is a sign operator', (value, expected) => {
+        expect(isSignOperator(value)).toStrictEqual(expected);
+    });
+});
+
+describe('isFunctionOperator', () => {
+    it('is a helper', () => {
+        expect(isFunctionOperator).toEqual(expect.any(Function));
+    });
+
+    it.each([
+        ['', false],
+        ['MUL', false],
+        ['SUB', false],
+        ['ADD', false],
+        ['NTHRT', true]
+    ])('tells if %s is a function operator', (value, expected) => {
         expect(isFunctionOperator(value)).toStrictEqual(expected);
     });
 });
@@ -147,6 +183,19 @@ describe('signOperators', () => {
     it('defines tokens', () => {
         expect(signOperators.length).toBeGreaterThan(0);
         signOperators.forEach(name => {
+            expect(terms[name]).toEqual(expect.any(Object));
+        });
+    });
+});
+
+describe('functionOperators', () => {
+    it('is a namespace', () => {
+        expect(functionOperators).toEqual(expect.any(Array));
+    });
+
+    it('defines tokens', () => {
+        expect(functionOperators.length).toBeGreaterThan(0);
+        functionOperators.forEach(name => {
             expect(terms[name]).toEqual(expect.any(Object));
         });
     });

--- a/src/utils/counter.js
+++ b/src/utils/counter.js
@@ -1,0 +1,50 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2023 Open Assessment Technologies SA ;
+ */
+
+/**
+ * Creates a counter that will increase a counter each time a flag is changed from `true` to `false`.
+ * @returns {counter}
+ */
+export function counterFactory() {
+    let counter = 0;
+    let flag = false;
+
+    /**
+     * @typedef {object} counter
+     */
+    return {
+        /**
+         * The number of counted occurrences.
+         * @type {number}
+         */
+        get count() {
+            return counter;
+        },
+
+        /**
+         * Check a state and increase the internal counter if the internal flag changes from `true` to `false`.
+         * @param {boolean} state
+         */
+        check(state = false) {
+            if (flag && !state) {
+                counter++;
+            }
+            flag = state;
+        }
+    };
+}

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,0 +1,21 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2023 Open Assessment Technologies SA ;
+ */
+
+/* c8 ignore start */
+export * from './counter.js';
+/* c8 ignore end */

--- a/src/utils/test/counter.spec.js
+++ b/src/utils/test/counter.spec.js
@@ -1,0 +1,47 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2023 Open Assessment Technologies SA ;
+ */
+
+import { counterFactory } from '../counter.js';
+
+describe('counter', () => {
+    it('is a factory', () => {
+        expect(counterFactory).toEqual(expect.any(Function));
+        expect(counterFactory()).toEqual(expect.any(Object));
+        expect(counterFactory()).not.toStrictEqual(counterFactory());
+    });
+
+    it('has a count property', () => {
+        const counter = counterFactory();
+        expect(counter.count).toStrictEqual(0);
+    });
+
+    it('does not count state changes from false to true', () => {
+        const counter = counterFactory();
+        expect(counter.count).toStrictEqual(0);
+        counter.check(true);
+        expect(counter.count).toStrictEqual(0);
+    });
+
+    it('count state changes from true to false', () => {
+        const counter = counterFactory();
+        expect(counter.count).toStrictEqual(0);
+        counter.check(true);
+        counter.check(false);
+        expect(counter.count).toStrictEqual(1);
+    });
+});


### PR DESCRIPTION
### Related to: https://oat-sa.atlassian.net/browse/TR-5071

### Summary

Requires: https://github.com/oat-sa/tao-calculator-fe/pull/18

PR 4/5 for adding the instant computation mode to the calculator:
- Add a strategy for deciding if the current expression needs to be evaluated before adding another term

Please see the details below for more info.
Other PR will come later for completing the feature.

### Details

Several changes have been made:
- a set of strategies has been added for detecting if the new term is an operator and deciding if the expression needs to be evaluated first
- a few helpers have been added too for checking tokens with a particular mean

### How to test
- run the unit tests: `npm test`