### PR TITLE
Feature/TR-5209/Remove lodash

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+        "moduleResolution": "Node",
+        "target": "ESNext",
+        "module": "ESNext",
+        "isolatedModules": true,
+        "resolveJsonModule": true,
+        "sourceMap": true,
+        "esModuleInterop": true,
+        "skipLibCheck": true,
+        "forceConsistentCasingInFileNames": true,
+        "baseUrl": ".",
+        "checkJs": false
+    },
+    "include": ["src/**/*.js", "sandbox/**/*.{js,svelte}"]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -6322,7 +6322,8 @@
         "lodash": {
             "version": "4.17.21",
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+            "dev": true
         },
         "lodash.debounce": {
             "version": "4.0.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1864,6 +1864,16 @@
             "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
             "dev": true
         },
+        "@jridgewell/source-map": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.2.tgz",
+            "integrity": "sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==",
+            "dev": true,
+            "requires": {
+                "@jridgewell/gen-mapping": "^0.3.0",
+                "@jridgewell/trace-mapping": "^0.3.9"
+            }
+        },
         "@jridgewell/sourcemap-codec": {
             "version": "1.4.14",
             "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
@@ -3103,6 +3113,12 @@
             "requires": {
                 "delayed-stream": "~1.0.0"
             }
+        },
+        "commander": {
+            "version": "2.20.3",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+            "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+            "dev": true
         },
         "comment-parser": {
             "version": "1.1.5",
@@ -7115,6 +7131,15 @@
             "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
             "dev": true
         },
+        "randombytes": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+            "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+            "dev": true,
+            "requires": {
+                "safe-buffer": "^5.1.0"
+            }
+        },
         "react-is": {
             "version": "18.2.0",
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
@@ -7488,6 +7513,46 @@
                 }
             }
         },
+        "rollup-plugin-terser": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-7.0.2.tgz",
+            "integrity": "sha512-w3iIaU4OxcF52UUXiZNsNeuXIMDvFrr+ZXK6bFZ0Q60qyVfq4uLptoS4bbq3paG3x216eQllFZX7zt6TIImguQ==",
+            "dev": true,
+            "requires": {
+                "@babel/code-frame": "^7.10.4",
+                "jest-worker": "^26.2.1",
+                "serialize-javascript": "^4.0.0",
+                "terser": "^5.0.0"
+            },
+            "dependencies": {
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "jest-worker": {
+                    "version": "26.6.2",
+                    "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.6.2.tgz",
+                    "integrity": "sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==",
+                    "dev": true,
+                    "requires": {
+                        "@types/node": "*",
+                        "merge-stream": "^2.0.0",
+                        "supports-color": "^7.0.0"
+                    }
+                },
+                "supports-color": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+                    "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                }
+            }
+        },
         "run-parallel": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -7579,6 +7644,15 @@
             "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
             "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
             "dev": true
+        },
+        "serialize-javascript": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
+            "integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
+            "dev": true,
+            "requires": {
+                "randombytes": "^2.1.0"
+            }
         },
         "set-blocking": {
             "version": "2.0.0",
@@ -7882,6 +7956,30 @@
                     "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
                     "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
                     "dev": true
+                }
+            }
+        },
+        "terser": {
+            "version": "5.16.8",
+            "resolved": "https://registry.npmjs.org/terser/-/terser-5.16.8.tgz",
+            "integrity": "sha512-QI5g1E/ef7d+PsDifb+a6nnVgC4F22Bg6T0xrBrz6iloVB4PUkkunp6V8nzoOOZJIzjWVdAGqCdlKlhLq/TbIA==",
+            "dev": true,
+            "requires": {
+                "@jridgewell/source-map": "^0.3.2",
+                "acorn": "^8.5.0",
+                "commander": "^2.20.0",
+                "source-map-support": "~0.5.20"
+            },
+            "dependencies": {
+                "source-map-support": {
+                    "version": "0.5.21",
+                    "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+                    "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+                    "dev": true,
+                    "requires": {
+                        "buffer-from": "^1.0.0",
+                        "source-map": "^0.6.0"
+                    }
                 }
             }
         },

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "dependencies": {
         "@oat-sa/expr-eval": "^2.1.2",
         "decimal.js": "^10.4.3",
-        "lodash": "^4.17.21",
         "moo": "^0.5.2"
     },
     "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
         "rollup-plugin-livereload": "^2.0.5",
         "rollup-plugin-serve": "^2.0.2",
         "rollup-plugin-svelte": "^7.1.3",
+        "rollup-plugin-terser": "^7.0.2",
         "svelte": "^3.55.1",
         "svelte-preprocess": "^5.0.1"
     },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -18,6 +18,7 @@
 
 import nodeResolve from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
+import { terser } from 'rollup-plugin-terser';
 
 export default {
     input: 'src/index.js',
@@ -26,6 +27,12 @@ export default {
             name: 'calculator',
             format: 'umd',
             file: 'dist/index.js'
+        },
+        {
+            name: 'calculator',
+            format: 'umd',
+            file: 'dist/index.min.js',
+            plugins: [terser()]
         }
     ],
     plugins: [commonjs(), nodeResolve()]

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -24,13 +24,11 @@ export default {
     input: 'src/index.js',
     output: [
         {
-            name: 'calculator',
-            format: 'umd',
+            format: 'es',
             file: 'dist/index.js'
         },
         {
-            name: 'calculator',
-            format: 'umd',
+            format: 'es',
             file: 'dist/index.min.js',
             plugins: [terser()]
         }


### PR DESCRIPTION
### Related to: https://oat-sa.atlassian.net/browse/TR-5209

### Summary

Remove `lodash` from the dependencies.

### Details

`lodash` was used for a few API that could be done using native implementation. It was not yet replaced because it needed some time.

Now lodash is replaced, and the dist bundle is also minified.

### How to test
- install: `npm i`
- run the tests: `npm test`
- build the bundle `npm run build` (it must generates 2 files in the `dist` folder)
- launch the sandbox and play with it: `npm run dev`