### PR TITLE
Fix/ADF-1568/Set the correct base branch in the release script

### DIFF
--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -36,4 +36,4 @@ jobs:
                   # install the package
                   npm ci
                   #create tag and release a new version
-                  taoRelease npmRelease --no-interactive
+                  taoRelease npmRelease --release-branch main --no-interactive


### PR DESCRIPTION
### Related to: https://oat-sa.atlassian.net/browse/ADF-1568

### Summary

Set the correct base branch in the release script.

The release job failed because the branch is not properly selected when the non-interactive mode is selected