### PR TITLE
fix: update expression render to show correct response for power of

### DIFF
--- a/src/core/expression.js
+++ b/src/core/expression.js
@@ -140,6 +140,9 @@ const expressionHelper = {
             } else {
                 resultString = fullString;
             }
+            if (resultString.includes('e+')) {
+                resultString = resultString.replace('e+', '*10^');
+            }
         }
         return resultString;
     },
@@ -294,8 +297,7 @@ const expressionHelper = {
                 exponentOnTheRight(renderedTerms, index);
             }
         });
-
-        return renderedTerms;
+        return expressionHelper.nestExponents(renderedTerms);
     },
 
     /**


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TR-6124

Bug steps to reproduce:
1. Launch the test from the preconditions ([launch link](https://devkit-ignite-qa.staging.gcp-eu.taocloud.org/platform/message/launch/lti-resource-link?registration=101_DeliverRegistration_qa_server&user_list=leia&custom_user_id=m2&custom_user_name=m2&launch_url=https://testrunner-ignite-qa.staging.gcp-eu.taocloud.org/api/v1/auth/launch-lti-1p3/a99ccc578c88&claims=%7B%0D%0A%20%20%20%20%22https://purl.imsglobal.org/spec/lti/claim/roles%22:%20%5B%0D%0A%20%20%20%20%20%20%20%20%22http://purl.imsglobal.org/vocab/lis/v2/membership%23Learner%22%0D%0A%20%20%20%20%5D%0D%0A%7D))
2. Click  “Calculator” icon in the upper right corner of the page
3. Multiply high numbers or raise number 10 to exponent (higher than 20)

**Expected result**: exponent part should be displayed as a superscript

Before:
![image](https://github.com/oat-sa/tao-calculator-fe/assets/133767102/00273530-5f6a-4d94-82c4-7274953d9659)

Now:

https://github.com/oat-sa/tao-calculator-fe/assets/133767102/2c4d0343-d9a7-4bda-9950-4dbee092e8d7

