### PR TITLE
fix: import files, not directories

### DIFF
--- a/src/core/engine.js
+++ b/src/core/engine.js
@@ -31,7 +31,7 @@ import {
     signStrategies,
     suffixStrategies,
     triggerStrategies
-} from './strategies';
+} from './strategies/index.js';
 import { isPrefixedTerm, terms } from './terms.js';
 import tokenizerFactory from './tokenizer.js';
 import tokensHelper from './tokens.js';

--- a/src/core/strategies/trigger.js
+++ b/src/core/strategies/trigger.js
@@ -16,8 +16,8 @@
  * Copyright (c) 2023 Open Assessment Technologies SA ;
  */
 
-import { counterFactory } from '../../utils';
-import { isFunctionOperator } from '../terms';
+import { counterFactory } from '../../utils/index.js';
+import { isFunctionOperator } from '../terms.js';
 import tokensHelper from '../tokens.js';
 
 /**

--- a/src/index.js
+++ b/src/index.js
@@ -17,6 +17,6 @@
  */
 
 /* c8 ignore start */
-export * from './core';
-export * from './plugins';
+export * from './core/index.js';
+export * from './plugins/index.js';
 /* c8 ignore end */


### PR DESCRIPTION
[Vitest](https://vitest.dev/) is complaining about the import of directories. This PR changes the directory imports to standard file imports.

Error: Directory import '{...}/nextgen-stack/tao-control-center/frontend/node_modules/@oat-sa/tao-calculator/src/core' is not supported resolving ES modules imported from {...}//nextgen-stack/tao-control-center/frontend/node_modules/@oat-sa/tao-calculator/src/index.js


Serialized Error: { url: 'file:///{...}//nextgen-stack/tao-control-center/frontend/node_modules/@oat-sa/tao-calculator/src/core', code: 'ERR_UNSUPPORTED_DIR_IMPORT' }

Node [mandates](https://nodejs.org/api/esm.html#import-specifiers) that:

> A file extension must be provided when using the import keyword to resolve relative or absolute specifiers. Directory indexes (e.g. './startup/index.js') must also be fully specified.


